### PR TITLE
Arbitrary-precision float arithmetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
-  - 2.5.0
   - ruby-head
 
 # For Ruby/GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
+  - 2.5.0
   - ruby-head
 
 # For Ruby/GSL

--- a/components.md
+++ b/components.md
@@ -329,7 +329,7 @@ Because of input restrictions, complex numbers are represented as an array in th
 |`Ær`|Pop `a`|Pushes the coefficients (as a list of complex numbers) of the polynomial with roots `a` (also a list of complex numbers) (i.e. `[[-0.5, 0.866], [-0.5, -0.866]] => [[1, 0], [1, 0], [1, 0]] (approximately)`).|
 |`Æs`|Pop `a`|Pushes the arcsine of `a`.|
 |`Æt`|Pop `a`|Pushes the arctangent of `a`.|
-|`Æu`|Pop `a`, `b`|Pushes the arctangent of `b / a` (`atan2`).|
+|`Æu`|Pop `a`, `b`|Pushes `atan2(b, a)`.|
 |`Æρ`|Pop `a`, `b`|Pushes the polynomial resulting from the multiplication of polynomials `a` and `b`, where `a`, `b`, and the result are all lists of real numbers representing coefficients.|
 |`Æ¬`|Pop `a`|Pushes the *complex* square root of `a`, where `a` is either a number or an array in the form `[real, imag]`.|
 |`Æ¤`|Pop `a`, `b`|Pushes the `b`th `a`-gonal number.|

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -420,7 +420,7 @@ class Ohm
         call: ->{'AEIOUaeiou'}
       },
       'e' => {
-        call: ->{BigMath.E(DECIMAL_PRECISION)}
+        call: ->{ohm_bigmath(:E)}
       },
       'q' => {
         call: ->{%w(qwertyuiop asdfghjkl zxcvbnm)}
@@ -429,10 +429,10 @@ class Ohm
         call: ->{'AEIOUYaeiouy'}
       },
       'π' => {
-        call: ->{BigMath.PI(DECIMAL_PRECISION)}
+        call: ->{ohm_bigmath(:PI)}
       },
       'φ' => {
-        call: ->{(1 + BigMath.sqrt(to_decimal(5), DECIMAL_PRECISION)) / 2}
+        call: ->{(1 + ohm_bigmath(:sqrt, to_decimal(5))) / 2}
       },
       'Γ' => {
         call: ->{
@@ -679,41 +679,41 @@ class Ohm
         depth: [1, 1]
       },
       'C' => {
-        call: ->(a){BigMath.cos(to_decimal(a), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:cos, to_decimal(a))}
       },
       'D' => {
-        call: ->(a){to_decimal(a) * (180 / BigMath.PI(DECIMAL_PRECISION))}
+        call: ->(a){to_decimal(a) * (180 / ohm_bigmath(:PI))}
       },
       'E' => {
-        call: ->(a){to_decimal(a) * (BigMath.PI(DECIMAL_PRECISION) / 180)}
+        call: ->(a){to_decimal(a) * (ohm_bigmath(:PI) / 180)}
       },
       'H' => {
-        call: ->(a, b){BigMath.sqrt((to_decimal(a) ** 2) + (to_decimal(b) ** 2), DECIMAL_PRECISION)}
+        call: ->(a, b){ohm_bigmath(:sqrt, (to_decimal(a) ** 2) + (to_decimal(b) ** 2))}
       },
       'L' => {
-        call: ->(a){BigMath.log(to_decimal(a), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:log, to_decimal(a))}
       },
       'M' => {
-        call: ->(a){BigMath.log(to_decimal(a), DECIMAL_PRECISION) / BigMath.log(to_decimal(10), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:log, to_decimal(a)) / ohm_bigmath(:log, to_decimal(10))}
       },
       'N' => {
-        call: ->(a){BigMath.log(to_decimal(a), DECIMAL_PRECISION) / BigMath.log(to_decimal(2), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:log, to_decimal(a)) / ohm_bigmath(:log, to_decimal(2))}
       },
       'R' => {
         call: ->(a){GSL::Poly[*a.map(&:to_f)].solve.to_a.each_slice(2).to_a},
         depth: [1]
       },
       'S' => {
-        call: ->(a){BigMath.sin(to_decimal(a), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:sin, to_decimal(a))}
       },
       'T' => {
-        call: ->(a){BigMath.sin(to_decimal(a), DECIMAL_PRECISION) / BigMath.cos(to_decimal(a), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:sin, to_decimal(a)) / ohm_bigmath(:cos, to_decimal(a))}
       },
       'c' => {
-        call: ->(a){x = to_decimal(a); BigMath.atan(BigMath.sqrt(1 - (x ** 2), DECIMAL_PRECISION) / x, DECIMAL_PRECISION)}
+        call: ->(a){x = to_decimal(a); ohm_bigmath(:atan, ohm_bigmath(:sqrt, 1 - (x ** 2)) / x)}
       },
       'l' => {
-        call: ->(a, b){BigMath.log(to_decimal(b), DECIMAL_PRECISION) / BigMath.log(to_decimal(a), DECIMAL_PRECISION)}
+        call: ->(a, b){ohm_bigmath(:log, to_decimal(b)) / ohm_bigmath(:log, to_decimal(a))}
       },
       'm' => {
         call: ->(a){a.map(&method(:to_decimal)).reduce(:+) / a.length},
@@ -735,13 +735,13 @@ class Ohm
         depth: [2]
       },
       's' => {
-        call: ->(a){x = to_decimal(a); BigMath.atan(x / BigMath.sqrt(1 - (x ** 2), DECIMAL_PRECISION), DECIMAL_PRECISION)}
+        call: ->(a){x = to_decimal(a); ohm_bigmath(:atan, x / ohm_bigmath(:sqrt, 1 - (x ** 2)))}
       },
       't' => {
-        call: ->(a){BigMath.atan(to_decimal(a), DECIMAL_PRECISION)}
+        call: ->(a){ohm_bigmath(:atan, to_decimal(a))}
       },
       'u' => {
-        call: ->(a, b){Math.atan2(b.to_f, a.to_f)}
+        call: ->(a, b){decimal_atan2(to_decimal(b), to_decimal(a))}
       },
       'ρ' => {
         call: ->(a, b){polynomial_mul(a.map(&method(:to_decimal)), b.map(&method(:to_decimal)))},
@@ -981,7 +981,7 @@ class Ohm
       call: ->(a, b){to_decimal(a) ** (1 / to_decimal(b))},
     },
     '¬' => {
-      call: ->(a){BigMath.sqrt(to_decimal(a), DECIMAL_PRECISION)},
+      call: ->(a){ohm_bigmath(:sqrt, to_decimal(a))},
     },
     '¢' => {
       call: ->(a){@vars[:register] = a},

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -157,11 +157,11 @@ class Ohm
       call: ->(a){@printed = true; puts untyped_to_s(a)}
     },
     '-' => {
-      call: ->(a, b){a.to_f - b.to_f}
+      call: ->(a, b){to_decimal(a) - to_decimal(b)}
     },
     # . reserved: character literal
     '/' => {
-      call: ->(a, b){a.to_f / b.to_f}
+      call: ->(a, b){to_decimal(a) / to_decimal(b)}
     },
     # 0-9 reserved: numeric literal
     # : reserved: foreach loop
@@ -700,7 +700,7 @@ class Ohm
         call: ->(a){Math.log2(a.to_f)}
       },
       'R' => {
-        call: ->(a){GSL::Poly[*a.map(&:to_f)].solve.to_a.each_slice(2).to_a},
+        call: ->(a){GSL::Poly[*a.map(&method(:to_decimal))].solve.to_a.each_slice(2).to_a},
         depth: [1]
       },
       'S' => {
@@ -881,10 +881,10 @@ class Ohm
       call: ->(a){a.to_i}
     },
     'í' => {
-      call: ->(a){a.to_f}
+      call: ->(a){to_decimal(a)}
     },
     'î' => {
-      call: ->(a){a.to_f % 1 == 0}
+      call: ->(a){to_decimal(a) % 1 == 0}
     },
     'ï' => {
       call: ->(a, b){untyped_to_s(a).split(untyped_to_s(b))},
@@ -945,7 +945,7 @@ class Ohm
       call: ->(a){nth_fibonacci(a.to_i)}
     },
     'þ' => {
-      call: ->(a){sleep(a.to_f); nil}
+      call: ->(a){sleep(to_decimal(a)); nil}
     },
     # upside down question mark reserved: else statement
     # interrobang reserved: break out of block/wire
@@ -956,13 +956,13 @@ class Ohm
       call: ->{}
     },
     '‰' => {
-      call: ->(a){2 ** a.to_f}
+      call: ->(a){2 ** to_decimal(a)}
     },
     '‱' => {
-      call: ->(a){10 ** a.to_f}
+      call: ->(a){10 ** to_decimal(a)}
     },
     '¦' => {
-      call: ->(a){a.to_f.round},
+      call: ->(a){to_decimal(a).round},
     },
     '§' => {
       call: ->(a){arr_else_chars(a).sample},
@@ -978,7 +978,7 @@ class Ohm
       arr_str: true
     },
     '±' => {
-      call: ->(a, b){a.to_f ** (1 / b.to_f)},
+      call: ->(a, b){to_decimal(a) ** (1 / to_decimal(b))},
     },
     '¬' => {
       call: ->(a){Math.sqrt(a.to_f)},
@@ -996,10 +996,10 @@ class Ohm
     },
     # right double angle bracket reserved: single-component map
     '‹' => {
-      call: ->(a){a.to_f - 1}
+      call: ->(a){to_decimal(a) - 1}
     },
     '›' => {
-      call: ->(a){a.to_f + 1}
+      call: ->(a){to_decimal(a) + 1}
     },
     # left quote reserved: base-255 literal
     # right quote reserved: Smaz-compressed string literal
@@ -1063,7 +1063,7 @@ class Ohm
         arr_str: true
       },
       '¦' => {
-        call: ->(a, b){a.to_f.round(b.to_i)}
+        call: ->(a, b){to_decimal(a).round(b.to_i)}
       }
     },
     # 2-dot reserved: two character literal

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -621,12 +621,12 @@ class Ohm
     },
     # capital theta reserved: execute previous wire
     'Π' => {
-      call: ->(a){arr_or_stack(a) {|a| a.map(&:to_f).reduce(:*)}},
+      call: ->(a){arr_or_stack(a) {|a| a.map(&method(:to_decimal)).reduce(:*)}},
       depth: [1],
       arr_stack: true
     },
     'Σ' => {
-      call: ->(a){arr_or_stack(a) {|a| a.map(&:to_f).reduce(:+)}},
+      call: ->(a){arr_or_stack(a) {|a| a.map(&method(:to_decimal)).reduce(:+)}},
       depth: [1],
       arr_stack: true
     },
@@ -667,60 +667,60 @@ class Ohm
         call: ->(a, b){a.to_i.lcm(b.to_i)}
       },
       '×' => {
-        call: ->(a, b){(Complex(*a.map(&:to_f)) ** Complex(*b.map(&:to_f))).rect},
+        call: ->(a, b){(Complex(*a.map(&method(:to_decimal))) ** Complex(*b.map(&method(:to_decimal)))).rect},
         depth: [1, 1]
       },
       '*' => {
-        call: ->(a, b){(Complex(*a.map(&:to_f)) * Complex(*b.map(&:to_f))).rect},
+        call: ->(a, b){(Complex(*a.map(&method(:to_decimal))) * Complex(*b.map(&method(:to_decimal)))).rect},
         depth: [1, 1]
       },
       '/' => {
-        call: ->(a, b){(Complex(*a.map(&:to_f)) / Complex(*b.map(&:to_f))).rect},
+        call: ->(a, b){(Complex(*a.map(&method(:to_decimal))) / Complex(*b.map(&method(:to_decimal)))).rect},
         depth: [1, 1]
       },
       'C' => {
-        call: ->(a){Math.cos(a.to_f)}
+        call: ->(a){BigMath.cos(to_decimal(a), DECIMAL_PRECISION)}
       },
       'D' => {
-        call: ->(a){a.to_f * (180 / Math::PI)}
+        call: ->(a){to_decimal(a) * (180 / BigMath.PI(DECIMAL_PRECISION))}
       },
       'E' => {
-        call: ->(a){a.to_f * (Math::PI / 180)}
+        call: ->(a){to_decimal(a) * (BigMath.PI(DECIMAL_PRECISION) / 180)}
       },
       'H' => {
-        call: ->(a, b){Math.hypot(a.to_f, b.to_f)}
+        call: ->(a, b){BigMath.sqrt((to_decimal(a) ** 2) + (to_decimal(b) ** 2), DECIMAL_PRECISION)}
       },
       'L' => {
-        call: ->(a){Math.log(a.to_f)}
+        call: ->(a){BigMath.log(to_decimal(a), DECIMAL_PRECISION)}
       },
       'M' => {
-        call: ->(a){Math.log10(a.to_f)}
+        call: ->(a){BigMath.log(to_decimal(a), DECIMAL_PRECISION) / BigMath.log(to_decimal(10), DECIMAL_PRECISION)}
       },
       'N' => {
-        call: ->(a){Math.log2(a.to_f)}
+        call: ->(a){BigMath.log(to_decimal(a), DECIMAL_PRECISION) / BigMath.log(to_decimal(2), DECIMAL_PRECISION)}
       },
       'R' => {
-        call: ->(a){GSL::Poly[*a.map(&method(:to_decimal))].solve.to_a.each_slice(2).to_a},
+        call: ->(a){GSL::Poly[*a.map(&:to_f)].solve.to_a.each_slice(2).to_a},
         depth: [1]
       },
       'S' => {
-        call: ->(a){Math.sin(a.to_f)}
+        call: ->(a){BigMath.sin(to_decimal(a), DECIMAL_PRECISION)}
       },
       'T' => {
-        call: ->(a){Math.tan(a.to_f)}
+        call: ->(a){BigMath.sin(to_decimal(a), DECIMAL_PRECISION) / BigMath.cos(to_decimal(a), DECIMAL_PRECISION)}
       },
       'c' => {
         call: ->(a){Math.acos(a.to_f)}
       },
       'l' => {
-        call: ->(a, b){Math.log(b.to_f) / Math.log(a.to_f)}
+        call: ->(a, b){BigMath.log(to_decimal(b), DECIMAL_PRECISION) / BigMath.log(to_decimal(a), DECIMAL_PRECISION)}
       },
       'm' => {
-        call: ->(a){a.map(&:to_f).reduce(:+) / a.length},
+        call: ->(a){a.map(&method(:to_decimal)).reduce(:+) / a.length},
         depth: [1]
       },
       'n' => {
-        call: ->(a){a = a.map(&:to_f).sort; (a[a.length.pred / 2] + a[a.length / 2]) / 2},
+        call: ->(a){a = a.map(&method(:to_decimal)).sort; (a[a.length.pred / 2] + a[a.length / 2]) / 2},
         depth: [1]
       },
       'o' => {
@@ -731,24 +731,24 @@ class Ohm
         call: ->(a, b){a.to_i.gcd(b.to_i) == 1}
       },
       'r' => {
-        call: ->(a){a.reduce([1]) {|m, r| polynomial_mul(m, [1, -Complex(*r.map(&:to_f))])}.map(&:rect)},
+        call: ->(a){a.reduce([1]) {|m, r| polynomial_mul(m, [1, -Complex(*r.map(&method(:to_decimal)))])}.map(&:rect)},
         depth: [2]
       },
       's' => {
         call: ->(a){Math.asin(a.to_f)}
       },
       't' => {
-        call: ->(a){Math.atan(a.to_f)}
+        call: ->(a){BigMath.atan(to_decimal(a), 20)}
       },
       'u' => {
         call: ->(a, b){Math.atan2(b.to_f, a.to_f)}
       },
       'ρ' => {
-        call: ->(a, b){polynomial_mul(a.map(&:to_f), b.map(&:to_f))},
+        call: ->(a, b){polynomial_mul(a.map(&method(:to_decimal)), b.map(&method(:to_decimal)))},
         depth: [1, 1]
       },
       '¬' => {
-        call: ->(a){CMath.sqrt(Complex(*a.map(&:to_f))).rect},
+        call: ->(a){CMath.sqrt(Complex(*a.map(&method(:to_decimal)))).rect},
         depth: [1]
       },
       '¤' => {
@@ -925,7 +925,7 @@ class Ohm
       arr_stack: true
     },
     'û' => {
-      call: ->(a, b, c){a.to_f.step(b.to_f, c.to_f).to_a}
+      call: ->(a, b, c){to_decimal(a).step(to_decimal(b), to_decimal(c)).to_a}
     },
     'ü' => {
       call: ->{}
@@ -981,7 +981,7 @@ class Ohm
       call: ->(a, b){to_decimal(a) ** (1 / to_decimal(b))},
     },
     '¬' => {
-      call: ->(a){Math.sqrt(a.to_f)},
+      call: ->(a){BigMath.sqrt(to_decimal(a), 20)},
     },
     '¢' => {
       call: ->(a){@vars[:register] = a},

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -420,7 +420,7 @@ class Ohm
         call: ->{'AEIOUaeiou'}
       },
       'e' => {
-        call: ->{Math::E}
+        call: ->{BigMath.E(DECIMAL_PRECISION)}
       },
       'q' => {
         call: ->{%w(qwertyuiop asdfghjkl zxcvbnm)}
@@ -429,10 +429,10 @@ class Ohm
         call: ->{'AEIOUYaeiouy'}
       },
       'π' => {
-        call: ->{Math::PI}
+        call: ->{BigMath.PI(DECIMAL_PRECISION)}
       },
       'φ' => {
-        call: ->{(1 + Math.sqrt(5)) / 2}
+        call: ->{(1 + BigMath.sqrt(to_decimal(5), DECIMAL_PRECISION)) / 2}
       },
       'Γ' => {
         call: ->{
@@ -710,7 +710,7 @@ class Ohm
         call: ->(a){BigMath.sin(to_decimal(a), DECIMAL_PRECISION) / BigMath.cos(to_decimal(a), DECIMAL_PRECISION)}
       },
       'c' => {
-        call: ->(a){Math.acos(a.to_f)}
+        call: ->(a){x = to_decimal(a); BigMath.atan(BigMath.sqrt(1 - (x ** 2), DECIMAL_PRECISION) / x, DECIMAL_PRECISION)}
       },
       'l' => {
         call: ->(a, b){BigMath.log(to_decimal(b), DECIMAL_PRECISION) / BigMath.log(to_decimal(a), DECIMAL_PRECISION)}
@@ -735,10 +735,10 @@ class Ohm
         depth: [2]
       },
       's' => {
-        call: ->(a){Math.asin(a.to_f)}
+        call: ->(a){x = to_decimal(a); BigMath.atan(x / BigMath.sqrt(1 - (x ** 2), DECIMAL_PRECISION), DECIMAL_PRECISION)}
       },
       't' => {
-        call: ->(a){BigMath.atan(to_decimal(a), 20)}
+        call: ->(a){BigMath.atan(to_decimal(a), DECIMAL_PRECISION)}
       },
       'u' => {
         call: ->(a, b){Math.atan2(b.to_f, a.to_f)}
@@ -981,7 +981,7 @@ class Ohm
       call: ->(a, b){to_decimal(a) ** (1 / to_decimal(b))},
     },
     '¬' => {
-      call: ->(a){BigMath.sqrt(to_decimal(a), 20)},
+      call: ->(a){BigMath.sqrt(to_decimal(a), DECIMAL_PRECISION)},
     },
     '¢' => {
       call: ->(a){@vars[:register] = a},

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -38,4 +38,6 @@ pqrstuvwxyz{|}~¶
   OPENERS = %w(? : M £ » ⁇ ⁈ ‼ € ς ‘ ’ χ Å É ·Ω ·Θ)
 
   QUOTES = %w(" “ ”)
+
+  DECIMAL_PRECISION = 10
 end

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -39,5 +39,5 @@ pqrstuvwxyz{|}~¶
 
   QUOTES = %w(" “ ”)
 
-  DECIMAL_PRECISION = 10
+  DECIMAL_PRECISION = 20
 end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -74,6 +74,10 @@ class Ohm
         nil
       end
     end
+    
+    def ohm_bigmath(meth, *args)
+      BigMath.method(meth).call(*args, DECIMAL_PRECISION)
+    end
 
     def bin_to_ohm(str)
       str.bytes.map {|b| Ohm::CODE_PAGE[b]}.join
@@ -91,6 +95,25 @@ class Ohm
       x = a.is_a?(Array) ? 1 + a.map {|c| comp_arg_depth(c, hsh)}.max.to_i : 0
       x += 1 if a.is_a?(String) && hsh[:arr_str]
       x
+    end
+
+    # Adapted from https://en.wikipedia.org/wiki/Atan2#Definition.
+    def decimal_atan2(y, x)
+      simple_atan = ohm_bigmath(:atan, y / x)
+      
+      if x > 0
+        simple_atan
+      elsif x < 0 && y >= 0
+        simple_atan + ohm_bigmath(:PI)
+      elsif x < 0 && y < 0
+        simple_atan - ohm_bigmath(:PI)
+      elsif x == 0 && y > 0
+        ohm_bigmath(:PI) / 2
+      elsif x == 0 && y < 0
+        -ohm_bigmath(:PI) / 2
+      else
+        to_decimal(0) # Sure, why not? It's what Jelly does.
+      end
     end
 
     # Shamefully stolen from Jelly.

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal/util'
 require 'set'
 
 require_relative 'constants'
@@ -369,6 +370,14 @@ class Ohm
         end
 
         num_converted.reverse.sub(/^0+/, '') # Remove leading zeroes
+      end
+    end
+
+    def to_decimal(val)
+      begin
+        val.to_d
+      rescue ArgumentError
+        BigDecimal(0)
       end
     end
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal'
 require 'bigdecimal/util'
 require 'set'
 
@@ -388,7 +389,12 @@ class Ohm
     end
 
     def untyped_to_s(n)
-      n.is_a?(Float) ? format("%.#{n.to_s.length}g", n) : n.to_s
+      if n.is_a?(Numeric)
+        x = to_decimal(n).to_s('F')
+        format("%.#{x.length}g", x)
+      else
+        n.to_s
+      end
     end
 
     def zip_arr(mat)

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -391,7 +391,8 @@ class Ohm
     def untyped_to_s(n)
       if n.is_a?(Numeric)
         x = to_decimal(n).to_s('F')
-        format("%.#{x.length}g", x)
+        return x[0...-2] if x =~ /\.0$/ # Remove trailing ".0" on integers
+        x
       else
         n.to_s
       end

--- a/spec/arithmetic_spec.rb
+++ b/spec/arithmetic_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Ohm do
       include_examples 'component', 'the coefficients of an array of polynomial roots', stack: [[[1, 0], [-1, 0]]], result: [[1, 0], [0, 0], [-1, 0]]
     end
     describe 'Æs' do
-      include_examples 'component', 'the arcsine of a number', stack: [1], result: Math::PI / 2
+      include_examples 'component', 'the arcsine of a number', stack: [1], result: Math::PI / 2, estimate: true
     end
     describe 'Æt' do
       include_examples 'component', 'the arctangent of a number', stack: [0], result: 0

--- a/spec/arithmetic_spec.rb
+++ b/spec/arithmetic_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Ohm do
       include_examples 'component', 'the arctangent of a number', stack: [0], result: 0
     end
     describe 'Æu' do
-      include_examples 'component', 'the arctangent of two numbers\' quotient (atan2)', stack: [1, 1], result: Math::PI / 4
+      include_examples 'component', 'the arctangent of two numbers\' quotient (atan2)', stack: [1, 1], result: Math::PI / 4, estimate: true
     end
     describe 'Æρ' do
       include_examples 'component', 'the polynomial multiplication of two arrays', stack: [[1, -2, 3], [-2, 1, 0]], result: [-2, 5, -8, 3, 0]

--- a/spec/arithmetic_spec.rb
+++ b/spec/arithmetic_spec.rb
@@ -13,40 +13,40 @@ RSpec.describe Ohm do
       include_examples 'component', 'the least common multiple of two numbers', stack: [27, 69], result: 621
     end
     describe 'Æ×' do
-      include_examples 'component', 'the complex exponentiation of two numbers', stack: [3, [2, -3]], result: [-8.89315134427972, 1.3826999557878903]
+      include_examples 'component', 'the complex exponentiation of two numbers', stack: [3, [2, -3]], result: [-8.8931513443, 1.3826999557], estimate: true
     end
     describe 'Æ*' do
       include_examples 'component', 'the complex multiplication of two numbers', stack: [[-3, 5], [2, -3]], result: [9, 19]
     end
     describe 'Æ/' do
-      include_examples 'component', 'the complex division of two numbers', stack: [[-3, 5], [2, -3]], result: [-1.6153846153846154, 0.07692307692307676]
+      include_examples 'component', 'the complex division of two numbers', stack: [[-3, 5], [2, -3]], result: [-1.6153846153, 0.0769230769], estimate: true
     end
     describe 'ÆC' do
       include_examples 'component', 'the cosine of a number in radians', stack: [0], result: 1
     end
     describe 'ÆD' do
-      include_examples 'component', 'a number in radians converted to degrees', stack: [Math::PI], result: 180
+      include_examples 'component', 'a number in radians converted to degrees', stack: [Math::PI], result: 180, estimate: true
     end
     describe 'ÆE' do
-      include_examples 'component', 'a number in degrees converted to radians', stack: [180], result: Math::PI
+      include_examples 'component', 'a number in degrees converted to radians', stack: [180], result: Math::PI, estimate: true
     end
     describe 'ÆH' do
       include_examples 'component', 'the hypotenuse of a right triangle with the given sides', stack: [3, 4], result: 5
     end
     describe 'ÆL' do
-      include_examples 'component', 'the natural logarithm of a number', stack: [Math::E], result: 1
+      include_examples 'component', 'the natural logarithm of a number', stack: [Math::E], result: 1, estimate: true
     end
     describe 'ÆM' do
-      include_examples 'component', 'the base 10 logarithm of a number', stack: [100], result: 2
+      include_examples 'component', 'the base 10 logarithm of a number', stack: [100], result: 2, estimate: true
     end
     describe 'ÆR' do
       include_examples 'component', 'the roots of an array of polynomial coefficients', stack: [[1, 0, -1]], result: [[1, 0], [-1, 0]]
     end
     describe 'ÆN' do
-      include_examples 'component', 'the base 2 logarithm of a number', stack: [32], result: 5
+      include_examples 'component', 'the base 2 logarithm of a number', stack: [32], result: 5, estimate: true
     end
     describe 'ÆS' do
-      include_examples 'component', 'the sine of a number in radians', stack: [Math::PI / 2], result: 1
+      include_examples 'component', 'the sine of a number in radians', stack: [Math::PI / 2], result: 1, estimate: true
     end
     describe 'ÆT' do
       include_examples 'component', 'the tangent of a number in radians', stack: [0], result: 0
@@ -55,7 +55,7 @@ RSpec.describe Ohm do
       include_examples 'component', 'the arccosine of a number', stack: [1], result: 0
     end
     describe 'Æl' do
-      include_examples 'component', 'the base-n logarithm of a number', stack: [5, 625], result: 4
+      include_examples 'component', 'the base-n logarithm of a number', stack: [5, 625], result: 4, estimate: true
     end
     describe 'Æm' do
       include_examples 'component', 'the arithmetic mean of an array of numbers', stack: [[2, 3, 4, 5]], result: 3.5

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Ohm do
       include_examples 'component', 'all vowels', result: 'AEIOUaeiou'
     end
     describe 'αe' do
-      include_examples 'component', 'Euler\'s constant', result: Math::E
+      include_examples 'component', 'Euler\'s constant', result: BigMath.E(Ohm::DECIMAL_PRECISION)
     end
     describe 'αq' do
       include_examples 'component', 'the lowercase alphabet ordered like a keyboard', result: %w(qwertyuiop asdfghjkl zxcvbnm)
@@ -40,10 +40,10 @@ RSpec.describe Ohm do
       include_examples 'component', 'all vowels including `y`', result: 'AEIOUYaeiouy'
     end
     describe 'απ' do
-      include_examples 'component', 'pi', result: Math::PI
+      include_examples 'component', 'pi', result: BigMath.PI(Ohm::DECIMAL_PRECISION)
     end
     describe 'αφ' do
-      include_examples 'component', 'phi', result: (1 + Math.sqrt(5)) / 2
+      include_examples 'component', 'phi', result: (1 + BigMath.sqrt(Ohm::Helpers.to_decimal(5), Ohm::DECIMAL_PRECISION)) / 2
     end
     describe 'αΓ' do
       include_examples 'component', 'an ASCII goat', result: <<-GOAT

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Ohm do
       include_examples 'component', 'all vowels', result: 'AEIOUaeiou'
     end
     describe 'αe' do
-      include_examples 'component', 'Euler\'s constant', result: BigMath.E(Ohm::DECIMAL_PRECISION)
+      include_examples 'component', 'Euler\'s constant', result: Ohm::Helpers.ohm_bigmath(:E)
     end
     describe 'αq' do
       include_examples 'component', 'the lowercase alphabet ordered like a keyboard', result: %w(qwertyuiop asdfghjkl zxcvbnm)
@@ -40,10 +40,10 @@ RSpec.describe Ohm do
       include_examples 'component', 'all vowels including `y`', result: 'AEIOUYaeiouy'
     end
     describe 'απ' do
-      include_examples 'component', 'pi', result: BigMath.PI(Ohm::DECIMAL_PRECISION)
+      include_examples 'component', 'pi', result: Ohm::Helpers.ohm_bigmath(:PI)
     end
     describe 'αφ' do
-      include_examples 'component', 'phi', result: (1 + BigMath.sqrt(Ohm::Helpers.to_decimal(5), Ohm::DECIMAL_PRECISION)) / 2
+      include_examples 'component', 'phi', result: (1 + Ohm::Helpers.ohm_bigmath(:sqrt, Ohm::Helpers.to_decimal(5))) / 2
     end
     describe 'αΓ' do
       include_examples 'component', 'an ASCII goat', result: <<-GOAT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,10 +69,23 @@ end
 
 require_relative '../ohm'
 
-RSpec.shared_examples 'component' do |desc, circuit: nil, result:, **ohm_opts|
+RSpec.shared_examples 'component' do |desc, circuit: nil, result:, estimate: false, **ohm_opts|
   it "pushes #{desc}" do
     # `self.class.description` cannot be the default value of `circuit:` because it depends on the `self` context
-    expect(Ohm.new(circuit || self.class.description, ohm_opts).exec.stack.last[0]).to eq(result)
+    elem = Ohm.new(circuit || self.class.description, ohm_opts).exec.stack.last[0]
+    
+    # Stupid BigDecimal/Float inaccuracies
+    if estimate
+      epsilon = 1e-6
+      
+      if result.is_a?(Array)
+        result.each_with_index {|r, i| expect(elem[i]).to be_between(r - epsilon, r + epsilon)}
+      else
+        expect(elem).to be_between(result - epsilon, result + epsilon)
+      end
+    else
+      expect(elem).to eq(result)
+    end
   end
 end
 


### PR DESCRIPTION
Changes all internal arithmetic to use BigDecimals instead of just floats. Should be a more permanent fix for #8.